### PR TITLE
マイクイズ機能の実装

### DIFF
--- a/app/controllers/my_quizzes_controller.rb
+++ b/app/controllers/my_quizzes_controller.rb
@@ -1,4 +1,17 @@
 class MyQuizzesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :correct_user
+
   def index
+    @quizzes = current_user.quizzes
+  end
+
+  private
+
+  def correct_user
+    user = User.find(params[:user_id])
+    return if current_user == user
+
+    redirect_to(root_path, alert: I18n.t('alerts.access_denied'))
   end
 end

--- a/app/controllers/my_quizzes_controller.rb
+++ b/app/controllers/my_quizzes_controller.rb
@@ -1,0 +1,4 @@
+class MyQuizzesController < ApplicationController
+  def index
+  end
+end

--- a/app/views/my_quizzes/index.html.erb
+++ b/app/views/my_quizzes/index.html.erb
@@ -1,0 +1,11 @@
+<h1>マイクイズ一覧</h1>
+
+<% if @quizzes.any? %>
+  <ul>
+    <% @quizzes.each do |quiz| %>
+      <li><%= link_to quiz.title, quiz_path(quiz) %></li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>クイズはまだありません。</p>
+<% end %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -2,7 +2,7 @@
   <ul>
     <li><%= link_to 'ホーム', root_path %></li>
     <% if user_signed_in? %>
-      <li><%= link_to 'マイクイズ' %></li>
+      <li><%= link_to 'マイクイズ', user_my_quizzes_path(current_user) %></li>
       <li><%= link_to 'お気に入り', user_favorite_quizzes_path(current_user) %></li>
       <li><%= link_to 'クイズ作成', new_quiz_path %></li>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,5 +28,6 @@ Rails.application.routes.draw do
 
   resources :users do
     resources :favorite_quizzes, only: [:index]
+    get 'my_quizzes', to: 'my_quizzes#index', as: 'my_quizzes'
   end
 end

--- a/spec/system/users/my_quizzes_spec.rb
+++ b/spec/system/users/my_quizzes_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'My Quizzes', type: :system do
+  let(:user) { create(:user) }
+  let(:another_user) { create(:user) }
+  let!(:quiz1) { create(:quiz, user:, title: 'Sample Quiz 1', description: 'Sample description 1') }
+  let!(:quiz2) { create(:quiz, user:, title: 'Sample Quiz 2', description: 'Sample description 2') }
+  let!(:quiz3) { create(:quiz, title: 'Sample Quiz 3', description: 'Sample description 3') }
+
+  describe 'マイクイズページの表示' do
+    context 'ログインユーザーの場合' do
+      before do
+        sign_in user
+      end
+
+      it 'ログインユーザーのクイズのみが表示されること' do
+        visit user_my_quizzes_path(user)
+        expect(page).to have_content 'Sample Quiz 1'
+        expect(page).to have_content 'Sample Quiz 2'
+        expect(page).not_to have_content 'Sample Quiz 3'
+      end
+
+      it 'クイズのリンクが表示されること' do
+        visit user_my_quizzes_path(user)
+        expect(page).to have_link 'Sample Quiz 1', href: quiz_path(quiz1)
+        expect(page).to have_link 'Sample Quiz 2', href: quiz_path(quiz2)
+      end
+    end
+
+    context '別のユーザーの場合' do
+      before do
+        sign_in another_user
+      end
+
+      it '他のユーザーのクイズページにアクセスできないこと' do
+        visit user_my_quizzes_path(user)
+        expect(page).to have_content 'アクセス権がありません'
+      end
+    end
+
+    context '未ログインユーザーの場合' do
+      it 'ログインページにリダイレクトされること' do
+        visit user_my_quizzes_path(user)
+        expect(page).to have_content 'ログインしてください。'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 概要

このプルリクエストでは、ログインユーザーが自身の作成したクイズを一覧表示する「マイクイズ」機能を実装しました。主な変更点は以下の通りです。

#### 変更内容

1. **MyQuizzesControllerの作成とアクセス制御の実装**
    - `index`アクションを追加し、ログインユーザーが作成したクイズを表示。
    - `before_action`コールバックで認証とユーザー検証を追加。不正なアクセスをルートパスにリダイレクトし、警告メッセージを表示。

2. **ルーティングの追加**
    - `my_quizzes`の`index`アクションをルーティングに追加。

3. **マイクイズページのビューを作成**
    - ログインユーザーが作成したクイズのリストを表示するためのビューを追加。
    - クイズが存在しない場合のメッセージを表示。

4. **ナビゲーションにマイクイズへのリンクを追加**
    - ログインユーザー向けにマイクイズページへのリンクをナビゲーションバーに追加。

5. **マイクイズ機能のシステムスペックを追加**
    - ログインユーザーが作成したクイズのみが表示されることをテスト。
    - 不正なユーザーが他のユーザーのクイズページにアクセスできないことを確認。
    - 未ログインユーザーがログインページにリダイレクトされることを確認。

#### テスト
- ログインユーザー、別のユーザー、未ログインユーザーの各ケースでの動作をシステムスペックで確認しました。

以上の変更により、ユーザーは自身の作成したクイズを一覧で確認できるようになりました。また、不正アクセスを防ぐための適切なアクセス制御も実装しています。





