### PR TITLE
[update]Dockerfile.prodにPumaの起動時に必要な`tmp/pids`ディレクトリを作成するコマンドを追加しました。

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -35,6 +35,9 @@ RUN bundle config set --local without 'development test'
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 
+# tmp/pidsディレクトリの作成
+RUN mkdir -p tmp/pids
+
 # アプリケーションコードのコピー
 COPY . .
 


### PR DESCRIPTION
## 背景
Heroku上でアプリケーションをデプロイする際に、Pumaが`tmp/pids/server.pid`ファイルを作成できずにクラッシュする問題が発生していました。これは、`tmp/pids`ディレクトリが存在しないためです。

## 変更内容
Dockerfile.prodに以下の変更を加えました:
- Pumaの起動時に必要な`tmp/pids`ディレクトリを作成するコマンドを追加しました。


## テスト
- ローカル環境およびHerokuでのデプロイ後に、Pumaが正常に起動することを確認しました。

このプルリクエストにより、Pumaの起動エラーが解消され、アプリケーションの安定性が向上します。レビューをよろしくお願いします。
