### PR TITLE
質問セクションの表示/非表示機能の改善とテストの追加

### DIFF
--- a/app/assets/stylesheets/pages/quizzes_show.scss
+++ b/app/assets/stylesheets/pages/quizzes_show.scss
@@ -126,6 +126,17 @@
 
   #questions-section {
     margin-top: 1rem;
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+    visibility: hidden;
+    transition: max-height 0.7s ease, opacity 0.7s ease;
+  }
+
+  #questions-section.open {
+    max-height: 900px;
+    opacity: 1;
+    visibility: visible;
   }
 
   #show-questions-btn,

--- a/app/javascript/quiz_details.js
+++ b/app/javascript/quiz_details.js
@@ -1,18 +1,19 @@
 document.addEventListener('turbo:load', () => {
-  const showQuestionsButton = document.getElementById('show-questions-btn');
+  const toggleQuestionsButton = document.getElementById('show-questions-btn');
   const questionsSection = document.getElementById('questions-section');
 
-  if (showQuestionsButton && questionsSection) {
-    // 質問セクションが表示されていたら、常に表示を維持する
+  if (toggleQuestionsButton && questionsSection) {
+    // ページ遷移後も状態を維持する
     if (window.location.search.includes('page=') || window.location.hash.includes('questions-section')) {
-      questionsSection.style.display = 'block';
-      showQuestionsButton.style.display = 'none';
-    } else {
-      // ボタンをクリックで質問セクションを表示
-      showQuestionsButton.addEventListener('click', function() {
-        questionsSection.style.display = 'block';
-        this.style.display = 'none';
-      });
+      questionsSection.classList.add('open');
+      toggleQuestionsButton.textContent = '質問を隠す';
     }
+
+    // トグルボタンのクリックイベント
+    toggleQuestionsButton.addEventListener('click', function () {
+      questionsSection.classList.toggle('open');
+      this.textContent = questionsSection.classList.contains('open') ? '質問を隠す' : '質問を表示';
+    });
   }
 });
+

--- a/app/views/quizzes/show.html.erb
+++ b/app/views/quizzes/show.html.erb
@@ -41,7 +41,7 @@
   <a name="questions-section"></a>
   <h2 class="quiz-details__questions-title">質問一覧</h2>
   <button id="show-questions-btn" class="button button--primary">質問を表示</button>
-  <div id="questions-section" style="display:none;">
+  <div id="questions-section">
     <ul class="quiz-details__questions-list">
       <% @questions.each do |question| %>
         <li class="quiz-details__question-item">

--- a/spec/system/quizzes/quiz_show_spec.rb
+++ b/spec/system/quizzes/quiz_show_spec.rb
@@ -15,10 +15,28 @@ RSpec.describe 'Quiz Show', type: :system do
       expect(page).to have_content 'Sample description'
     end
 
-    it 'クイズに関連する質問が表示されること', js: true do
-      visit quiz_path(quiz)
-      click_button '質問を表示'
-      expect(page).to have_content 'Sample Question'
+    context '「質問を表示」ボタンと質問セクションの動作',js: true do
+      before do
+        visit quiz_path(quiz)
+      end
+
+      it '初期状態では「質問を表示」と表示され、質問セクションが非表示になっていること' do
+        expect(page).to have_button('質問を表示')
+        expect(page).not_to have_content('Sample Question')
+      end
+
+      it '「質問を表示」をクリックするとボタンが「質問を隠す」に切り替わり、質問セクションが表示されること' do
+        click_button '質問を表示'
+        expect(page).to have_button('質問を隠す')
+        expect(page).to have_content('Sample Question')
+      end
+
+      it '「質問を隠す」をクリックするとボタンが「質問を表示」に戻り、質問セクションが非表示になること' do
+        click_button '質問を表示'
+        click_button '質問を隠す'
+        expect(page).to have_button('質問を表示')
+        expect(page).not_to have_content('Sample Question')
+      end
     end
 
     it 'QRコードが表示されていること' do

--- a/spec/system/quizzes/quiz_show_spec.rb
+++ b/spec/system/quizzes/quiz_show_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Quiz Show', type: :system do
       expect(page).to have_content 'Sample description'
     end
 
-    context '「質問を表示」ボタンと質問セクションの動作',js: true do
+    context '「質問を表示」ボタンと質問セクションの動作', js: true do
       before do
         visit quiz_path(quiz)
       end


### PR DESCRIPTION
#### **変更内容**
1. **質問セクションの表示/非表示機能の改善**
   - 質問セクションにアニメーションを追加。
     - `max-height`, `opacity`, `visibility` を使用して滑らかな開閉を実現。
     - `.open` クラスで表示状態を制御。
   - JavaScriptでトグルボタンを実装。
     - ボタンのクリックで質問セクションを開閉。
     - ボタンラベルを「質問を表示」「質問を隠す」で動的に切り替え。
   - 質問セクションの初期状態で設定されていた `style="display:none;"` を削除し、CSSで制御。

2. **システムスペックの追加**
   - 「質問を表示」ボタンの初期状態を確認。
   - ボタンクリック時のラベル切り替えを確認。
   - 質問セクションの表示/非表示の切り替えをテスト。
   - `context` を活用して関連するテストをグループ化。
