### PR TITLE
質問がない場合の表示とテストを追加

### DIFF
--- a/app/assets/stylesheets/pages/quizzes_show.scss
+++ b/app/assets/stylesheets/pages/quizzes_show.scss
@@ -209,4 +209,10 @@
       padding: 0;
     }
   }
+
+  &____no-questions {
+    text-align: center;
+    font-size: 1.5rem;
+    margin-top: 1rem;
+  }
 }

--- a/app/views/quizzes/show.html.erb
+++ b/app/views/quizzes/show.html.erb
@@ -40,23 +40,27 @@
 
   <a name="questions-section"></a>
   <h2 class="quiz-details__questions-title">質問一覧</h2>
-  <button id="show-questions-btn" class="button button--primary">質問を表示</button>
-  <div id="questions-section">
-    <ul class="quiz-details__questions-list">
-      <% @questions.each do |question| %>
-        <li class="quiz-details__question-item">
-          <%= link_to question.question_text, quiz_question_path(@quiz, question), class: 'quiz-details__question-link' %>
-          <% if user_signed_in? && @quiz.user == current_user %>
-            <%= button_to '質問を削除', quiz_question_path(@quiz, question), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'quiz-details__question-delete button button--danger' %>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
+  <% if @questions.any? %>
+    <button id="show-questions-btn" class="button button--primary">質問を表示</button>
+    <div id="questions-section">
+      <ul class="quiz-details__questions-list">
+        <% @questions.each do |question| %>
+          <li class="quiz-details__question-item">
+            <%= link_to question.question_text, quiz_question_path(@quiz, question), class: 'quiz-details__question-link' %>
+            <% if user_signed_in? && @quiz.user == current_user %>
+              <%= button_to '質問を削除', quiz_question_path(@quiz, question), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'quiz-details__question-delete button button--danger' %>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
 
-    <div class="quiz-details__pagination">
-      <%= paginate @questions, params: { anchor: 'questions-section' } %>
+      <div class="quiz-details__pagination">
+        <%= paginate @questions, params: { anchor: 'questions-section' } %>
+      </div>
     </div>
-  </div>
+  <% else %>
+    <p class="quiz-details__no-questions">質問は一件もありません</p>
+  <% end %>
 
   <% if user_signed_in? && @quiz.user == current_user %>
     <div>

--- a/spec/system/quizzes/quiz_show_spec.rb
+++ b/spec/system/quizzes/quiz_show_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe 'Quiz Show', type: :system do
       expect(page).to have_content 'Sample description'
     end
 
+    it 'QRコードが表示されていること' do
+      visit quiz_path(quiz)
+      expect(page).to have_css('.quiz-details__qr-code svg')
+    end
+
     context '「質問を表示」ボタンと質問セクションの動作', js: true do
       before do
         visit quiz_path(quiz)
@@ -39,9 +44,19 @@ RSpec.describe 'Quiz Show', type: :system do
       end
     end
 
-    it 'QRコードが表示されていること' do
-      visit quiz_path(quiz)
-      expect(page).to have_css('.quiz-details__qr-code svg')
+    context '質問がない場合' do
+      before do
+        quiz.questions.destroy_all
+        visit quiz_path(quiz)
+      end
+
+      it '「質問は一件もありません」と表示されること' do
+        expect(page).to have_content('質問は一件もありません')
+      end
+
+      it '質問セクションが非表示になっていること' do
+        expect(page).not_to have_css('#questions-section')
+      end
     end
 
     context 'ログインしている場合' do


### PR DESCRIPTION

#### **1. 質問がない場合の表示を改善**
- 質問が一件もない場合に「質問は一件もありません」と表示する機能を実装。
- 新しいクラス `quiz-details__no-questions` を追加し、以下のスタイルを適用：
  - テキストの中央揃え。
  - フォントサイズの拡大。
  - 適切な余白を設定。

#### **2. 質問がない場合のテストを追加**
- 質問が一件もない状態で以下を確認するテストを追加：
  - 「質問は一件もありません」と表示されること。
  - 質問セクションが非表示であること。
